### PR TITLE
Fix dataset creation notebook

### DIFF
--- a/create_COVIDx.ipynb
+++ b/create_COVIDx.ipynb
@@ -67,6 +67,7 @@
     "mapping['Klebsiella'] = 'pneumonia'\n",
     "mapping['Chlamydophila'] = 'pneumonia'\n",
     "mapping['Legionella'] = 'pneumonia'\n",
+    "mapping['E.Coli'] = 'pneumonia'\n",
     "mapping['Normal'] = 'normal'\n",
     "mapping['Lung Opacity'] = 'pneumonia'\n",
     "mapping['1'] = 'pneumonia'\n",
@@ -107,7 +108,7 @@
      "output_type": "stream",
      "text": [
       "Data distribution from covid datasets:\n",
-      "{'normal': 0, 'pneumonia': 33, 'COVID-19': 358}\n"
+      "{'normal': 0, 'pneumonia': 57, 'COVID-19': 617}\n"
      ]
     }
    ],
@@ -119,7 +120,7 @@
     "covid_ds = {'cohen': [], 'fig1': [], 'actmed': [], 'sirm': []}\n",
     "\n",
     "for index, row in cohen_csv.iterrows():\n",
-    "    f = row['finding'].split(',')[0] # take the first finding, for the case of COVID-19, ARDS\n",
+    "    f = row['finding'].split('/')[-1] # take final finding in hierarchy, for the case of COVID-19, ARDS\n",
     "    if f in mapping: # \n",
     "        count[mapping[f]] += 1\n",
     "        entry = [str(row['patientid']), row['filename'], mapping[f], 'cohen']\n",
@@ -185,7 +186,7 @@
       "Key:  COVID-19\n",
       "Test patients:  ['19', '20', '36', '42', '86', '94', '97', '117', '132', '138', '144', '150', '163', '169', '174', '175', '179', '190', '191COVID-00024', 'COVID-00025', 'COVID-00026', 'COVID-00027', 'COVID-00029', 'COVID-00030', 'COVID-00032', 'COVID-00033', 'COVID-00035', 'COVID-00036', 'COVID-00037', 'COVID-00038', 'ANON24', 'ANON45', 'ANON126', 'ANON106', 'ANON67', 'ANON153', 'ANON135', 'ANON44', 'ANON29', 'ANON201', 'ANON191', 'ANON234', 'ANON110', 'ANON112', 'ANON73', 'ANON220', 'ANON189', 'ANON30', 'ANON53', 'ANON46', 'ANON218', 'ANON240', 'ANON100', 'ANON237', 'ANON158', 'ANON174', 'ANON19', 'ANON195', 'COVID-19(119)', 'COVID-19(87)', 'COVID-19(70)', 'COVID-19(94)', 'COVID-19(215)', 'COVID-19(77)', 'COVID-19(213)', 'COVID-19(81)', 'COVID-19(216)', 'COVID-19(72)', 'COVID-19(106)', 'COVID-19(131)', 'COVID-19(107)', 'COVID-19(116)', 'COVID-19(95)', 'COVID-19(214)', 'COVID-19(129)']\n",
       "test count:  {'normal': 0, 'pneumonia': 5, 'COVID-19': 100}\n",
-      "train count:  {'normal': 0, 'pneumonia': 28, 'COVID-19': 258}\n"
+      "train count:  {'normal': 0, 'pneumonia': 52, 'COVID-19': 517}\n"
      ]
     }
    ],
@@ -278,7 +279,7 @@
      "output_type": "stream",
      "text": [
       "test count:  {'normal': 885, 'pneumonia': 594, 'COVID-19': 100}\n",
-      "train count:  {'normal': 7966, 'pneumonia': 5451, 'COVID-19': 258}\n"
+      "train count:  {'normal': 7966, 'pneumonia': 5475, 'COVID-19': 517}\n"
      ]
     }
    ],
@@ -337,9 +338,9 @@
      "output_type": "stream",
      "text": [
       "Final stats\n",
-      "Train count:  {'normal': 7966, 'pneumonia': 5451, 'COVID-19': 258}\n",
+      "Train count:  {'normal': 7966, 'pneumonia': 5475, 'COVID-19': 517}\n",
       "Test count:  {'normal': 885, 'pneumonia': 594, 'COVID-19': 100}\n",
-      "Total length of train:  13675\n",
+      "Total length of train:  13958\n",
       "Total length of test:  1579\n"
      ]
     }


### PR DESCRIPTION
## Description

Fixes #95 and adds E.Coli->pneumonia to the mapping.

The [covid-chestxray-dataset](https://github.com/ieee8023/covid-chestxray-dataset) repo changed the format of their "finding" field in metadata.csv, causing the notebook to parse the findings incorrectly.

## Context of change

Please add options that are relevant and mark any boxes that apply.

- [X] Software (software that runs on the PC)
- [ ] Library (library that runs on the PC)
- [ ] Tool (tool that assists coding development)
- [ ] Other

## Type of change

Please mark any boxes that apply.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested by running the create_COVIDx.ipynb notebook as usual.

## Checklist:

Please mark any boxes that have been completed.

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
